### PR TITLE
WASA - Cookie without secure flag

### DIFF
--- a/bahmni-proxy/resources/abdm-service-rewrite.conf
+++ b/bahmni-proxy/resources/abdm-service-rewrite.conf
@@ -11,6 +11,3 @@ RewriteRule /hiprovider(.*) http://hiu:8003$1 [P]
 RewriteCond %{REQUEST_URI} ^/hiprovider/*
 RewriteRule /hiprovider(.*) http://hip:80$1 [P]
 
-RewriteCond %{REQUEST_URI} ^/openmrs/*
-RewriteCond %{HTTP_COOKIE} ^.*JSESSIONID=([^;]+)
-RewriteRule ^.*$ - [CO=reporting_session:%1:%{HTTP_HOST}:86400:/:false:true]

--- a/bahmni-proxy/resources/security-header-proxy.conf
+++ b/bahmni-proxy/resources/security-header-proxy.conf
@@ -11,6 +11,6 @@
     Header always set X-Content-Type-Options "nosniff"
     Header always set X-Frame-Options "SAMEORIGIN"
     Header always set X-Permitted-Cross-Domain-Policies "none"
-    Header always edit Set-Cookie "(.*)" "$1; Secure"
+    Header onsuccess edit Set-Cookie ^(.*)$ $1;Secure
 # Set sever to Apache to prevent information disclosure
     Header always set Server "Apache"


### PR DESCRIPTION
1. Updated Header to onsuccess edit to secure cookies
2. Removed rewrite rule for JSESSIONID from abdm-service-rewrite.conf as its already there in bahmni-proxy.conf with secure flag
