### PR TITLE
Deepthi M|GOK-332|Updated to fix the WASA- Improper Error Handling issue 

### DIFF
--- a/bahmni-emr/package/docker/Dockerfile
+++ b/bahmni-emr/package/docker/Dockerfile
@@ -7,7 +7,14 @@ COPY bahmni-emr/distro/target/distro/openhmis.inventory*.omod ${OPENMRS_APPLICAT
 COPY bahmni-emr/distro/target/distro/jasperreport*.omod ${OPENMRS_APPLICATION_DATA_DIRECTORY}/modules/
 COPY bahmni-emr/distro/target/distro/hwcinventory*.omod ${OPENMRS_APPLICATION_DATA_DIRECTORY}/modules/
 
+
 # Replace FHIR2 Extension Module
 #TODO: Remove this once product image is upgraded with latest FHIR2 Extension Module
 RUN rm -f ${OPENMRS_APPLICATION_DATA_DIRECTORY}/modules/fhir2Extension-*.omod
 COPY bahmni-emr/distro/target/distro/fhir2Extension-*.omod ${OPENMRS_APPLICATION_DATA_DIRECTORY}/modules/
+
+# Replace openmrs-module-webservice-rest
+#TODO: Remove this once product image is upgraded with latest openmrs-module-webservice-rest>=2.41.0
+RUN rm -f ${OPENMRS_APPLICATION_DATA_DIRECTORY}/modules/webservices.rest-*.omod
+COPY bahmni-emr/resources/webservices.rest-*.omod ${OPENMRS_APPLICATION_DATA_DIRECTORY}/modules/
+


### PR DESCRIPTION
Modified the openmrs-module-webservices-rest omod to  not show the details of error response .so made this as a configuration so that we can disable it if we do not want to show the stacktrace in error response as showing the detailed stack trace is exposing details of implementation.
However this is a temporary PR and needs to be reverted once the test cases are fixed from openmrs-module-webservice-rest repo and PR's are  to be created and merged.