### PR TITLE
Fix. Minio URL name resolution in Avni

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -380,6 +380,8 @@ services:
     ports:
       - "8021:8021"
       - "8030:8030"
+    extra_hosts:
+      - "minio.avni.local: ${HOSTNAME}"
 
   avni_db:
     image: bahmnihwc/avni-db:${AVNI_DB_IMAGE_TAG:?}


### PR DESCRIPTION
This PR adds a extra_hosts configuration so that MinIO domain resolves to the host machine's IP address